### PR TITLE
A few bug fixes

### DIFF
--- a/mo_gym/deep_sea_treasure/deep_sea_treasure.py
+++ b/mo_gym/deep_sea_treasure/deep_sea_treasure.py
@@ -162,6 +162,7 @@ class DeepSeaTreasure(gym.Env):
 
     def reset(self, seed=None, return_info=False, **kwargs):
         super().reset(seed=seed)
+        self.np_random.seed(seed)
 
         self.current_state = np.array([0, 0], dtype=np.int32)
         self.step_count = 0.0

--- a/mo_gym/deep_sea_treasure/deep_sea_treasure.py
+++ b/mo_gym/deep_sea_treasure/deep_sea_treasure.py
@@ -71,7 +71,7 @@ class DeepSeaTreasure(gym.Env):
 
         # action space specification: 1 dimension, 0 up, 1 down, 2 left, 3 right
         self.action_space = Discrete(4)
-        self.reward_space = Box(low=np.array([0, -1]), high=np.array([23.7, -1]), dtype=np.float32)
+        self.reward_space = Box(low=np.array([0, -1]), high=np.array([np.max(self.sea_map), -1]), dtype=np.float32)
 
         self.current_state = np.array([0, 0], dtype=np.int32)
 
@@ -162,7 +162,6 @@ class DeepSeaTreasure(gym.Env):
 
     def reset(self, seed=None, return_info=False, **kwargs):
         super().reset(seed=seed)
-        self.np_random.seed(seed)
 
         self.current_state = np.array([0, 0], dtype=np.int32)
         self.step_count = 0.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license="MIT",
     packages=["mo_gym"],
     install_requires=[
-        "gym",
+        "gym==0.24.1", # 0.25 has breaking changes
         "numpy",
         "pygame",
         "scipy",


### PR DESCRIPTION
DST: 
* The bounds of the rewards were hardcoded for the convex map. 
* The way to fix the seed is deprecated. From what I saw in the official gym envs, the seed is now fixed just using the reset method. (e.g. https://github.com/openai/gym/blob/master/gym/envs/classic_control/cartpole.py#L198)

`setup.py`:
* Gym 0.25.0 introduces breaking changes. So I fixed the version to 0.24.1. 