### PR TITLE
Add MO reward wrappers

### DIFF
--- a/mo_gym/utils.py
+++ b/mo_gym/utils.py
@@ -2,7 +2,6 @@ from typing import Tuple, TypeVar
 
 import gym
 import numpy as np
-from gym.wrappers import NormalizeReward
 from gym.wrappers.normalize import RunningMeanStd
 
 ObsType = TypeVar("ObsType")
@@ -40,6 +39,7 @@ class LinearReward(gym.Wrapper):
 class MONormalizeReward(gym.Wrapper):
     """
     Wrapper to normalize the reward component at index idx. Does not touch other reward components.
+    Based on Gym's implementation: https://github.com/openai/gym/blob/master/gym/wrappers/normalize.py#L113
     """
 
     def __init__(self, env: gym.Env, idx: int, gamma: float = 0.99, epsilon: float = 1e-8):
@@ -81,7 +81,7 @@ class MONormalizeReward(gym.Wrapper):
 
 
 class MOClipReward(gym.RewardWrapper):
-    r""""Clip reward to [min, max]. """
+    """"Clip reward[idx] to [min, max]. """
 
     def __init__(self, env: gym.Env, idx: int, min_r, max_r):
         super().__init__(env)

--- a/mo_gym/utils.py
+++ b/mo_gym/utils.py
@@ -1,10 +1,8 @@
-from typing import Tuple, TypeVar, Iterator, Optional, Union, Sequence
+from typing import Tuple, TypeVar, Iterator
 
 import gym
 import numpy as np
-from gym import Space
-from gym.vector import VectorEnv, SyncVectorEnv
-from gym.vector.utils import batch_space, create_empty_array
+from gym.vector import SyncVectorEnv
 from gym.wrappers.normalize import RunningMeanStd
 
 ObsType = TypeVar("ObsType")

--- a/mo_gym/utils.py
+++ b/mo_gym/utils.py
@@ -60,7 +60,7 @@ class MONormalizeReward(gym.Wrapper):
         self.gamma = gamma
         self.epsilon = epsilon
 
-    def step(self, action):
+    def step(self, action: ActType):
         """Steps through the environment, normalizing the rewards returned."""
         obs, rews, dones, infos = self.env.step(action)
         to_normalize = rews[self.idx]
@@ -78,3 +78,17 @@ class MONormalizeReward(gym.Wrapper):
         """Normalizes the rewards with the running mean rewards and their variance."""
         self.return_rms.update(self.returns)
         return rews / np.sqrt(self.return_rms.var + self.epsilon)
+
+
+class MOClipReward(gym.RewardWrapper):
+    r""""Clip reward to [min, max]. """
+
+    def __init__(self, env: gym.Env, idx: int, min_r, max_r):
+        super().__init__(env)
+        self.idx = idx
+        self.min_r = min_r
+        self.max_r = max_r
+
+    def reward(self, reward):
+        reward[self.idx] = np.clip(reward[self.idx], self.min_r, self.max_r)
+        return reward

--- a/mo_gym/utils.py
+++ b/mo_gym/utils.py
@@ -2,6 +2,8 @@ from typing import Tuple, TypeVar
 
 import gym
 import numpy as np
+from gym.wrappers import NormalizeReward
+from gym.wrappers.normalize import RunningMeanStd
 
 ObsType = TypeVar("ObsType")
 ActType = TypeVar("ActType")
@@ -16,6 +18,7 @@ class LinearReward(gym.Wrapper):
     """Wrapper for Multi-Objective Envs
     Makes the env return a scalar reward, which is the the dot-product between the reward vector and the weight vector.
     """
+
     def __init__(self, env: gym.Env, weight: np.ndarray = None):
         super().__init__(env)
         if weight is None:
@@ -30,5 +33,48 @@ class LinearReward(gym.Wrapper):
         observation, reward, done, info = self.env.step(action)
         scalar_reward = np.dot(reward, self.w)
         info['vector_reward'] = reward
-        
+
         return observation, scalar_reward, done, info
+
+
+class MONormalizeReward(gym.Wrapper):
+    """
+    Wrapper to normalize the reward component at index idx. Does not touch other reward components.
+    """
+
+    def __init__(self, env: gym.Env, idx: int, gamma: float = 0.99, epsilon: float = 1e-8):
+        """This wrapper will normalize immediate rewards s.t. their exponential moving average has a fixed variance.
+
+             Args:
+                 env (env): The environment to apply the wrapper
+                 idx (int): the index of the reward to normalize
+                 epsilon (float): A stability parameter
+                 gamma (float): The discount factor that is used in the exponential moving average.
+             """
+        super().__init__(env)
+        self.idx = idx
+        self.num_envs = getattr(env, "num_envs", 1)
+        self.is_vector_env = getattr(env, "is_vector_env", False)
+        self.return_rms = RunningMeanStd(shape=())
+        self.returns = np.zeros(self.num_envs)
+        self.gamma = gamma
+        self.epsilon = epsilon
+
+    def step(self, action):
+        """Steps through the environment, normalizing the rewards returned."""
+        obs, rews, dones, infos = self.env.step(action)
+        to_normalize = rews[self.idx]
+        if not self.is_vector_env:
+            to_normalize = np.array([to_normalize])
+        self.returns = self.returns * self.gamma + to_normalize
+        to_normalize = self.normalize(to_normalize)
+        self.returns[dones] = 0.0
+        if not self.is_vector_env:
+            to_normalize = to_normalize[0]
+        rews[self.idx] = to_normalize
+        return obs, rews, dones, infos
+
+    def normalize(self, rews):
+        """Normalizes the rewards with the running mean rewards and their variance."""
+        self.return_rms.update(self.returns)
+        return rews / np.sqrt(self.return_rms.var + self.epsilon)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -69,7 +69,7 @@ def test_mo_sync_wrapper():
 
         return thunk
 
-    num_envs = 2
+    num_envs = 3
     envs = MOSyncVectorEnv([
         make_env("deep-sea-treasure-v0") for _ in range(num_envs)
     ])

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,8 +1,6 @@
-import gym
 import numpy as np
 
 import mo_gym
-from gym.utils.env_checker import check_env
 from mo_gym import MONormalizeReward, MOClipReward
 
 
@@ -26,7 +24,7 @@ def test_normalization_wrapper():
     for i in range(30):
         go_to_8_3(both_norm_env)
     both_norm_env.reset()
-    _, rewards, _, _ = both_norm_env.step(1)
+    _, rewards, _, _ = both_norm_env.step(1)  # down
     np.testing.assert_allclose(rewards, [0.18, -1.24], rtol=0, atol=1e-2)
     rewards = go_to_8_3(both_norm_env)
     np.testing.assert_allclose(rewards, [2.13, -1.24], rtol=0, atol=1e-2)
@@ -35,8 +33,8 @@ def test_normalization_wrapper():
     for i in range(30):
         go_to_8_3(norm_treasure_env)
     norm_treasure_env.reset()
-    _, rewards, _, _ = norm_treasure_env.step(1)
-    # Steps are not normalized
+    _, rewards, _, _ = norm_treasure_env.step(1)  # down
+    # Time rewards are not normalized (-1)
     np.testing.assert_allclose(rewards, [0.18, -1.], rtol=0, atol=1e-2)
     rewards = go_to_8_3(norm_treasure_env)
     np.testing.assert_allclose(rewards, [2.13, -1.], rtol=0, atol=1e-2)
@@ -49,14 +47,15 @@ def test_clip_wrapper():
 
     # Tests for both rewards clipped
     both_clipped_env.reset()
-    _, rewards, _, _ = both_clipped_env.step(1)
+    _, rewards, _, _ = both_clipped_env.step(1)  # down
     np.testing.assert_allclose(rewards, [0.5, -0.5], rtol=0, atol=1e-2)
     rewards = go_to_8_3(both_clipped_env)
     np.testing.assert_allclose(rewards, [0.5, -0.5], rtol=0, atol=1e-2)
 
     # Tests for only treasure clipped
     clip_treasure_env.reset()
-    _, rewards, _, _ = clip_treasure_env.step(1)
+    _, rewards, _, _ = clip_treasure_env.step(1)  # down
+    # Time rewards are not clipped (-1)
     np.testing.assert_allclose(rewards, [0.5, -1.], rtol=0, atol=1e-2)
     rewards = go_to_8_3(clip_treasure_env)
     np.testing.assert_allclose(rewards, [0.5, -1.], rtol=0, atol=1e-2)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -3,36 +3,60 @@ import numpy as np
 
 import mo_gym
 from gym.utils.env_checker import check_env
-from mo_gym import MONormalizeReward
+from mo_gym import MONormalizeReward, MOClipReward
+
+
+def go_to_8_3(env):
+    """
+    Goes to (8.2, -3) treasure, returns the rewards
+    """
+    env.reset()
+    env.step(3)  # right
+    env.step(1)  # down
+    _, rewards, _, _ = env.step(1)
+    return rewards
 
 
 def test_normalization_wrapper():
-    def finish_episode(env):
-        env.reset()
-        # Goes to (8.2, -3)
-        env.step(3)  # right
-        env.step(1)  # down
-        _, rewards, _, _ = env.step(1)
-        return rewards
-
     env = mo_gym.make('deep-sea-treasure-v0')
-    # Normalize both rewards
     norm_treasure_env = MONormalizeReward(env, idx=0)
     both_norm_env = MONormalizeReward(norm_treasure_env, idx=1)
+
+    # Tests for both rewards normalized
     for i in range(30):
-        finish_episode(both_norm_env)
+        go_to_8_3(both_norm_env)
     both_norm_env.reset()
     _, rewards, _, _ = both_norm_env.step(1)
     np.testing.assert_allclose(rewards, [0.18, -1.24], rtol=0, atol=1e-2)
-    rewards = finish_episode(both_norm_env)
+    rewards = go_to_8_3(both_norm_env)
     np.testing.assert_allclose(rewards, [2.13, -1.24], rtol=0, atol=1e-2)
 
-    # Normalize only treasure
+    # Tests for only treasure normalized
     for i in range(30):
-        finish_episode(norm_treasure_env)
+        go_to_8_3(norm_treasure_env)
     norm_treasure_env.reset()
     _, rewards, _, _ = norm_treasure_env.step(1)
     # Steps are not normalized
     np.testing.assert_allclose(rewards, [0.18, -1.], rtol=0, atol=1e-2)
-    rewards = finish_episode(norm_treasure_env)
+    rewards = go_to_8_3(norm_treasure_env)
     np.testing.assert_allclose(rewards, [2.13, -1.], rtol=0, atol=1e-2)
+
+
+def test_clip_wrapper():
+    env = mo_gym.make('deep-sea-treasure-v0')
+    clip_treasure_env = MOClipReward(env, idx=0, min_r=0, max_r=0.5)
+    both_clipped_env = MOClipReward(clip_treasure_env, idx=1, min_r=-0.5, max_r=0)
+
+    # Tests for both rewards clipped
+    both_clipped_env.reset()
+    _, rewards, _, _ = both_clipped_env.step(1)
+    np.testing.assert_allclose(rewards, [0.5, -0.5], rtol=0, atol=1e-2)
+    rewards = go_to_8_3(both_clipped_env)
+    np.testing.assert_allclose(rewards, [0.5, -0.5], rtol=0, atol=1e-2)
+
+    # Tests for only treasure clipped
+    clip_treasure_env.reset()
+    _, rewards, _, _ = clip_treasure_env.step(1)
+    np.testing.assert_allclose(rewards, [0.5, -1.], rtol=0, atol=1e-2)
+    rewards = go_to_8_3(clip_treasure_env)
+    np.testing.assert_allclose(rewards, [0.5, -1.], rtol=0, atol=1e-2)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,0 +1,38 @@
+import gym
+import numpy as np
+
+import mo_gym
+from gym.utils.env_checker import check_env
+from mo_gym import MONormalizeReward
+
+
+def test_normalization_wrapper():
+    def finish_episode(env):
+        env.reset()
+        # Goes to (8.2, -3)
+        env.step(3)  # right
+        env.step(1)  # down
+        _, rewards, _, _ = env.step(1)
+        return rewards
+
+    env = mo_gym.make('deep-sea-treasure-v0')
+    # Normalize both rewards
+    norm_treasure_env = MONormalizeReward(env, idx=0)
+    both_norm_env = MONormalizeReward(norm_treasure_env, idx=1)
+    for i in range(30):
+        finish_episode(both_norm_env)
+    both_norm_env.reset()
+    _, rewards, _, _ = both_norm_env.step(1)
+    np.testing.assert_allclose(rewards, [0.18, -1.24], rtol=0, atol=1e-2)
+    rewards = finish_episode(both_norm_env)
+    np.testing.assert_allclose(rewards, [2.13, -1.24], rtol=0, atol=1e-2)
+
+    # Normalize only treasure
+    for i in range(30):
+        finish_episode(norm_treasure_env)
+    norm_treasure_env.reset()
+    _, rewards, _, _ = norm_treasure_env.step(1)
+    # Steps are not normalized
+    np.testing.assert_allclose(rewards, [0.18, -1.], rtol=0, atol=1e-2)
+    rewards = finish_episode(norm_treasure_env)
+    np.testing.assert_allclose(rewards, [2.13, -1.], rtol=0, atol=1e-2)


### PR DESCRIPTION
I added two wrappers commonly used: normalize and clip.

The idea is to provide the index of the reward component you want to normalize or clip, and leave the other components as they are. Of course, wrappers can be wrapped inside others to normalize all rewards (see tests).